### PR TITLE
SecurityMethod refactoring CADC-50

### DIFF
--- a/cadc-registry/build.gradle
+++ b/cadc-registry/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.5.10'
+version = '1.5.11'
 
 dependencies {
     compile 'log4j:log4j:[1.2.17,)'

--- a/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
+++ b/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
@@ -175,13 +175,17 @@ public class Standards {
 
     public static final URI DOI_INSTANCES_10 = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/DOI#instances-1.0");
 
+    // Security method standardIDs
+    public static final URI SECURITY_METHOD_PASSWORD = URI.create("ivo://ivoa.net/sso#tls-with-password");
+    public static final URI SECURITY_METHOD_OAUTH = URI.create("ivo://ivoa.net/sso#OAuth");
+    public static final URI SECURITY_METHOD_OPENID = URI.create("ivo://ivoa.net/sso#OpenID");
+    
+    // Security methods
     public static final URI SECURITY_METHOD_ANON = URI.create("ivo://ivoa.net/sso#anon");
     public static final URI SECURITY_METHOD_CERT = URI.create("ivo://ivoa.net/sso#tls-with-certificate");
     public static final URI SECURITY_METHOD_COOKIE = URI.create("ivo://ivoa.net/sso#cookie");
     public static final URI SECURITY_METHOD_HTTP_BASIC = URI.create("ivo://ivoa.net/sso#BasicAA");
-    public static final URI SECURITY_METHOD_OAUTH = URI.create("ivo://ivoa.net/sso#OAuth");
-    public static final URI SECURITY_METHOD_OPENID = URI.create("ivo://ivoa.net/sso#OpenID");
-    public static final URI SECURITY_METHOD_TOKEN = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Auth#token-1.0");
+    public static final URI SECURITY_METHOD_TOKEN = URI.create("ivo://ivoa.net/sso#token");
 
     // interface type identifiers: <namespace uri>#<type attr name without rpefix>
     public static URI INTERFACE_PARAM_HTTP = URI.create(XMLConstants.VODATASERVICE_11_NS + "#ParamHTTP");

--- a/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
+++ b/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
@@ -186,6 +186,9 @@ public class Standards {
     public static final URI SECURITY_METHOD_COOKIE = URI.create("ivo://ivoa.net/sso#cookie");
     public static final URI SECURITY_METHOD_HTTP_BASIC = URI.create("ivo://ivoa.net/sso#BasicAA");
     public static final URI SECURITY_METHOD_TOKEN = URI.create("ivo://ivoa.net/sso#token");
+    
+    @Deprecated // Was for prototype delegation token work. Use SECURITY_METHOD_TOKEN now.
+    public static final URI SECURITY_METHOD_DELTOKEN = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Auth#token-1.0");
 
     // interface type identifiers: <namespace uri>#<type attr name without rpefix>
     public static URI INTERFACE_PARAM_HTTP = URI.create(XMLConstants.VODATASERVICE_11_NS + "#ParamHTTP");

--- a/cadc-registry/src/test/resources/multi-sec-capabilities.xml
+++ b/cadc-registry/src/test/resources/multi-sec-capabilities.xml
@@ -8,7 +8,7 @@
       <accessURL use="base"> https://example.net/srv </accessURL>
       <securityMethod/>
       <securityMethod standardID="ivo://ivoa.net/sso#tls-with-certificate"/>
-      <securityMethod standardID="vos://cadc.nrc.ca~vospace/CADC/std/Auth#token-1.0"/>
+      <securityMethod standardID="ivo://ivoa.net/sso#token"/>
     </interface>
   </capability>
 


### PR DESCRIPTION
- Changed `#token` to have ivoa authority
- Added missing `#tls-with-password`
- Organize by standardIDs, then securityMethods