### PR TITLE
CADC-10641: remove tar reference from PKG_10 standard

### DIFF
--- a/cadc-registry/build.gradle
+++ b/cadc-registry/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.5.13'
+version = '1.5.14'
 
 description = 'OpenCADC Registry client library'
 def git_url = 'https://github.com/opencadc/reg'

--- a/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
+++ b/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
@@ -163,7 +163,7 @@ public class Standards {
     public static final URI LOGGING_CONTROL_10 = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Logging#control-1.0");
 
     // Standard for package requests (ie zip or tar)
-    public static final URI PKG_10 = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Pkg-1.0");
+    public static final URI PKG_10 = URI.create("vos://cadc.nrc.ca~vault/CADC/std/Pkg-1.0");
 
     // batch processing
     public static final URI PROC_JOBS_10 = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Proc#jobs-1.0");

--- a/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
+++ b/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
@@ -162,7 +162,8 @@ public class Standards {
     
     public static final URI LOGGING_CONTROL_10 = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Logging#control-1.0");
 
-    public static final URI PKG_10 = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Pkg#tar-1.0");
+    // Standard for package requests (ie zip or tar)
+    public static final URI PKG_10 = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Pkg-1.0");
 
     // batch processing
     public static final URI PROC_JOBS_10 = URI.create("vos://cadc.nrc.ca~vospace/CADC/std/Proc#jobs-1.0");


### PR DESCRIPTION
type of package will be communicated by another means - a pkg endpoint will be a consistent URL for all types of package available. 