### PR TITLE
cadc-registry: add DAP-2.1 standardID for prototype

### DIFF
--- a/cadc-registry/src/main/java/ca/nrc/cadc/reg/CapabilitiesReader.java
+++ b/cadc-registry/src/main/java/ca/nrc/cadc/reg/CapabilitiesReader.java
@@ -263,6 +263,15 @@ public class CapabilitiesReader {
             return null;
         }
         try {
+            // try to resolve java system prop reference
+            if (standardIDString.startsWith("${") && standardIDString.endsWith("}")) {
+                String prop = standardIDString.substring(2, standardIDString.length() - 1);
+                String val = System.getProperty(prop);
+                log.warn("resolve: " + prop + " = " + val);
+                if (val != null) {
+                    standardIDString = val;
+                }
+            }
             return new URI(standardIDString);
         } catch (URISyntaxException ex) {
             throw new IllegalArgumentException("invalid standardID: " + standardIDString, ex);

--- a/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
+++ b/cadc-registry/src/main/java/ca/nrc/cadc/reg/Standards.java
@@ -102,6 +102,7 @@ public class Standards {
 
     public static final URI SIA_10 = URI.create("ivo://ivoa.net/std/SIA");
     public static final URI SIA_QUERY_20 = URI.create("ivo://ivoa.net/std/SIA#query-2.0");
+    public static final URI DAP_QUERY_21 = URI.create("ivo://ivoa.net/std/DAP#query-2.1");
     //public static final URI SIA_META_2x = URI.create("ivo://ivoa.net/std/SIA#metadata-2.x");
 
     // Simple Cone Search 1.1


### PR DESCRIPTION
dynamic standardID: resolve java system prop to value allows use of ${blah} in capabilities xml doc and replacing the value while reading