### PR TITLE
fix: hostname fix for src gms

### DIFF
--- a/cadc-registry-server/reg-resource-caps.properties
+++ b/cadc-registry-server/reg-resource-caps.properties
@@ -66,7 +66,7 @@ ivo://oats.inaf.it/vospace = http://space01.oats.inaf.it/vospace/capabilities
 ivo://canfar.net/src/skaha = https://src.canfar.net/skaha/capabilities
 ivo://canfar.net/src/cavern = https://src.canfar.net/cavern/capabilities
 ivo://canfar.net/src/posix-mapper = https://src.canfar.net/posix-mapper/capabilities
-ivo://skao.int/gms = https://permissions.srcdev.skao.int/api/v1/gms/capabilities
+ivo://skao.int/gms = https://permissions.srcnet.skao.int/api/v1/gms/capabilities
 
 # MAST caom2 metadata service
 ivo://mast.stsci.edu/caom2repo = https://mast.stsci.edu/portal/ArchivePartner/meta-service/capabilities


### PR DESCRIPTION
SKAO has transitioned (mostly) away from the `srcdev` hostnames in favour of the `srcnet` hostnames.  This corrects the registry appropriately.